### PR TITLE
fix(lsp): resolve highlights.scm via tree-sitter-rsm package root

### DIFF
--- a/packages/rsm-lsp/src/layer1/semanticTokens.ts
+++ b/packages/rsm-lsp/src/layer1/semanticTokens.ts
@@ -2,7 +2,7 @@ import { Tree } from 'tree-sitter';
 import { Query, QueryCapture } from 'tree-sitter';
 import { SemanticTokensBuilder } from 'vscode-languageserver';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { logger } from '../utils/logger';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -129,15 +129,28 @@ export class SemanticTokensProvider {
    */
   private loadHighlightQuery() {
     try {
-      // Try multiple paths to support both development and production
-      const possiblePaths = [
-        // Production: compiled to dist/
-        join(__dirname, '../../../tree-sitter-rsm/queries/highlights.scm'),
+      // Try multiple paths to support both development and production.
+      const possiblePaths: string[] = [];
+
+      // Primary: resolve relative to the tree-sitter-rsm package root. This is
+      // layout-independent (works whether the package sits at the monorepo root
+      // in dev or inside node_modules in the prod/Docker image). Resolving the
+      // package.json rather than the main entry avoids the "main": "bindings/node"
+      // offset that made the older require.resolve(...)/../queries path miss.
+      try {
+        const pkgRoot = dirname(require.resolve('tree-sitter-rsm/package.json'));
+        possiblePaths.push(join(pkgRoot, 'queries/highlights.scm'));
+      } catch {
+        // package.json not resolvable in this context; fall through to relative guesses.
+      }
+
+      // Fallbacks for a tree-sitter-rsm checkout adjacent to the repo root.
+      possiblePaths.push(
         // Development: running from src/
         join(__dirname, '../../../../tree-sitter-rsm/queries/highlights.scm'),
-        // Alternative: resolve from tree-sitter-rsm package
-        join(require.resolve('tree-sitter-rsm'), '../queries/highlights.scm'),
-      ];
+        // Production: compiled to dist/
+        join(__dirname, '../../../tree-sitter-rsm/queries/highlights.scm'),
+      );
 
       let querySource: string | null = null;
       let loadedPath: string | null = null;


### PR DESCRIPTION
## Problem

rsm-lsp crashes at startup in the prod/Docker layout:

```
Error: Could not find highlights.scm in any expected location
    at SemanticTokensProvider.loadHighlightQuery (dist/layer1/semanticTokens.js:140)
```

This takes the LSP process down under supervisord and makes the **Studio backend `/health` return 503** (the `services` check reports `lsp is not running / FATAL Exited too quickly`). Core editing and Y.js sync still work; LSP diagnostics/autocomplete do not. Surfaced while verifying the studio prod deploy on 2026-07-02.

## Root cause

None of `loadHighlightQuery`'s three search paths resolve in the containerized `node_modules` layout:

- The two `__dirname`-relative paths assume a `tree-sitter-rsm` checkout adjacent to the repo root (dev/monorepo layout). In the Docker image `tree-sitter-rsm` lives under `rsm-lsp/node_modules/tree-sitter-rsm`, so neither path exists.
- The `require.resolve('tree-sitter-rsm')` fallback appended `../queries/highlights.scm`. But `tree-sitter-rsm/package.json` sets `"main": "bindings/node"`, so `require.resolve` returns `.../tree-sitter-rsm/bindings/node/index.js` and the join lands on `.../bindings/node/queries/highlights.scm` (missing). The `queries/` dir is at the package root, which needs `../../queries` from the main entry, not `../queries`.

This has been broken in the prod layout since semantic tokens were added; the dev path (`../../../../tree-sitter-rsm/...` from `src/`) masked it locally.

## Fix

Resolve relative to the package root via `dirname(require.resolve('tree-sitter-rsm/package.json'))`, which is layout-independent (monorepo root in dev, `node_modules` in prod). The `__dirname`-relative paths remain as fallbacks.

## Verification

- `tsc` builds clean.
- Running the resolution from the compiled `dist/layer1` context finds `tree-sitter-rsm/queries/highlights.scm` (`EXISTS = true`).
- Full `vitest` + live-server runs were not possible on this machine (Node 25 lacks the rollup and tree-sitter native builds); prod builds both in Docker on linux/node20.

## Rollout

Studio's deploy clones `aris-pub/rsm` main and rebuilds rsm-lsp, so once this merges to rsm main a studio backend redeploy will restore prod `/health` to 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZfTQx3v4o3aK8V8fi86ot