### PR TITLE
ci: cancel superseded runs and cache Playwright browsers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# Cancel superseded runs on the same ref (e.g. a new push to a PR) so they stop
+# competing for the shared runner pool instead of piling up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lsp-tests:
@@ -189,6 +195,7 @@ jobs:
 
     env:
       PYTEST_ADDOPTS: "--color=yes"
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.pw-browsers
 
     steps:
     - name: Checkout the repository and submodules
@@ -208,6 +215,12 @@ jobs:
 
     - name: Install rsm-lang
       run: uv sync
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.pw-browsers
+        key: playwright-${{ runner.os }}-${{ hashFiles('uv.lock') }}
 
     - name: Install Playwright browsers
       run: uv run playwright install --with-deps chromium
@@ -246,6 +259,7 @@ jobs:
 
     env:
       PYTEST_ADDOPTS: "--color=yes"
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.pw-browsers
 
     steps:
     - name: Checkout the repository and submodules
@@ -267,6 +281,12 @@ jobs:
       run: |
         uv sync
         uv pip list
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.pw-browsers
+        key: playwright-${{ runner.os }}-${{ hashFiles('uv.lock') }}
 
     - name: Install Playwright browsers
       run: |


### PR DESCRIPTION
Two low-risk changes to stop CI runs piling up on the shared runner pool and re-doing work every run. **Every job still runs on every PR — no coverage removed.**

- **Concurrency group with `cancel-in-progress`** — pushing again to a PR cancels the in-flight run instead of both queueing for runners. Directly reduces the runner contention that's been starving/cancelling jobs.
- **Cache the Playwright browser download** in `interactive-tests` and `accessibility-tests` (keyed on `uv.lock`, which pins the Playwright version) so Chromium isn't re-downloaded from scratch every run.

`visual-tests`' browser download + its macOS pinning are handled separately by moving it into a pinned Playwright **Linux** container (follow-up — it carries a large regenerated-baseline diff, so it's kept out of this small workflow change).

Part of std-c3f5.