### PR TITLE
ci: run accessibility tests on ubuntu instead of macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,7 +265,9 @@ jobs:
       run: uv run python -m sphinx -b html -W docs/source docs/build/html
 
   accessibility-tests:
-    runs-on: macos-latest
+    # Linux (amd64) instead of the scarce macOS pool. These are axe-core rule
+    # checks (no pixel snapshots), so rendering platform doesn't matter.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     env:


### PR DESCRIPTION
The accessibility tests are axe-core rule checks (`Axe().run(page)`), not pixel snapshots, so they don't need macOS rendering. Moves the last `macos-latest` job off the scarce/expensive runner pool onto `ubuntu-latest` (Playwright cache already applies). No baselines to regenerate. Follow-up to std-c3f5.