### PR TITLE
fix(brand): point brand asset fetch at aris-pub/brand + allow override

### DIFF
--- a/rsm/brand_assets.py
+++ b/rsm/brand_assets.py
@@ -5,10 +5,17 @@ maintaining offline build capability. See docs/source/_static/BRAND_ASSETS.md
 for the full rationale.
 """
 
+import os
 import urllib.request
 from pathlib import Path
 
-BRAND_BASE_URL = "https://raw.githubusercontent.com/leotrs/brand/main/logos"
+# Canonical brand repo is aris-pub/brand. Kept as a build-time raw fetch with a
+# committed fallback (see the functions below), so a network miss is harmless.
+# Override with RSM_BRAND_BASE_URL if the assets ever move to a dedicated host.
+BRAND_BASE_URL = os.environ.get(
+    "RSM_BRAND_BASE_URL",
+    "https://raw.githubusercontent.com/aris-pub/brand/main/logos",
+)
 
 
 def update_brand_assets_if_online(static_dir: Path) -> None:


### PR DESCRIPTION
`BRAND_BASE_URL` in `rsm/brand_assets.py` hardcoded `raw.githubusercontent.com/leotrs/brand` (a personal fork). The canonical repo is now `aris-pub/brand`, and GitHub raw does not reliably follow repo-rename redirects, so the build-time fetch (Sphinx docs + `rsm init`) was silently failing and falling back to the committed assets.

- Point `BRAND_BASE_URL` at `aris-pub/brand`.
- Read an optional `RSM_BRAND_BASE_URL` env override for when the assets move to a dedicated host.

Still a build-time fetch with a committed fallback, so a network miss remains harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)